### PR TITLE
Signal Python 3 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
I've done a quick review of `django-debug-toolbar-template-profiler` and it appears to support Python 3. It would be handy to signal this in the trove classifiers.

Note: I've tried to run the tests but the test setup doesn't appear to be complete, if you have instructions for running the tests I'd be happy to do this.

Also I am not familiar with the low level details of this code, so you may know reasons why this is _not_ Python 3 compatible – if so please let me know and I'll look into fixing them.