### PR TITLE
Depend on debug toolbar 1.1+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='Simplified BSD License',
     packages=find_packages(),
     install_requires=[
-        'django-debug-toolbar>=1.0',
+        'django-debug-toolbar>=1.1',
     ],
     include_package_data=True,
     zip_safe=False,                 # because we're including static files

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -6,6 +6,7 @@ from django.dispatch import Signal
 from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar.panels import Panel
+from debug_toolbar.panels.sql.utils import contrasting_color_generator
 
 from django.template import Template as DjangoTemplate
 
@@ -14,18 +15,6 @@ try:
     from jinja2 import Template as JinjaTemplate
 except ImportError:
     jinja_import = False
-
-
-def dummy_color_generator():
-    while True:
-        yield '#bbbbbb'
-
-# Contrasting_color_generator is available since debug toolbar version 1.1.
-try:
-    from debug_toolbar.panels.sql.utils import contrasting_color_generator
-except ImportError:
-    # Support older versions of debug toolbar
-    contrasting_color_generator = dummy_color_generator
 
 template_rendered = Signal(
     providing_args=['instance', 'start', 'end', 'level'])


### PR DESCRIPTION
[django-debug-toolbar 1.1](https://pypi.org/project/django-debug-toolbar/1.1/) was released April 2014, over 5 years ago, so it is safe to depend on it now. `contrasting_color_generator` still lives in the same module.