### PR TITLE
Monkey patch templates only when the panel is used

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,8 @@ Pending Release
 * Skip templates as configured in django-debug-toolbar's
   ``SKIP_TEMPLATE_PREFIXES`` setting
   (`PR #11 <https://github.com/node13h/django-debug-toolbar-template-profiler/pull/11>`__).
+* Only monkey patch ``Template.render()`` methods if the panel is in use
+  (`PR #12 <https://github.com/node13h/django-debug-toolbar-template-profiler/pull/12>`__).
 
 1.0.2 (2017-05-03)
 ------------------

--- a/template_profiler_panel/apps.py
+++ b/template_profiler_panel/apps.py
@@ -1,52 +1,6 @@
-import inspect
-from time import time
-
-import wrapt
 from django.apps import AppConfig
-
-from template_profiler_panel.signals import template_rendered
 
 
 class TemplateProfilerPanelAppConfig(AppConfig):
     name = "template_profiler_panel"
     verbose_name = "Debug Toolbar Template Profiler Panel"
-
-    def ready(self):
-        self.monkey_patch_template_classes()
-
-    def monkey_patch_template_classes(self):
-        from django.template import Template as DjangoTemplate
-        template_classes = [DjangoTemplate]
-
-        try:
-            from jinja2 import Template as Jinja2Template
-        except ImportError:
-            pass
-        else:
-            template_classes.append(Jinja2Template)
-
-        @wrapt.decorator
-        def render_wrapper(wrapped, instance, args, kwargs):
-            start = time()
-            result = wrapped(*args, **kwargs)
-            end = time()
-
-            stack_depth = 1
-            current_frame = inspect.currentframe()
-            while True:
-                current_frame = current_frame.f_back
-                if current_frame is None:
-                    break
-                stack_depth += 1
-
-            template_rendered.send(
-                sender=instance.__class__,
-                instance=instance,
-                start=start,
-                end=end,
-                level=stack_depth,
-            )
-            return result
-
-        for template_class in template_classes:
-            template_class.render = render_wrapper(template_class.render)

--- a/template_profiler_panel/signals.py
+++ b/template_profiler_panel/signals.py
@@ -1,3 +1,0 @@
-from django.dispatch import Signal
-
-template_rendered = Signal(providing_args=['instance', 'start', 'end', 'level'])


### PR DESCRIPTION
Fixes #6. This moves the monkey patching code from the AppConfig to the panel class, so that when the panel is first instantiated, it then does the monkey patching. This allows the app to be installed with the panel disabled without any overhead.