### PR TITLE
Fix compatibility with django-debug-toolbar 2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Upgrade to support django-debug-toolbar 2.0+.
+
 1.1.0 (2019-09-06)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='Simplified BSD License',
     packages=find_packages(),
     install_requires=[
-        'django-debug-toolbar>=1.1,<2.0',
+        'django-debug-toolbar>=2.0',
         'wrapt',
     ],
     include_package_data=True,

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -144,7 +144,9 @@ class TemplateProfilerPanel(Panel):
 
         return result
 
-    def process_response(self, request, response):
+    def process_request(self, request):
+        response = super(TemplateProfilerPanel, self).process_request(request)
+
         summary = defaultdict(float)
 
         # Collect stats
@@ -169,3 +171,5 @@ class TemplateProfilerPanel(Panel):
         self.record_stats(
             {'templates': sorted(self.templates, key=lambda d: d['start']),
              'summary': sorted(summary.items(), key=lambda t: -t[1])})
+
+        return response


### PR DESCRIPTION
Fixes https://github.com/node13h/django-debug-toolbar-template-profiler/issues/8

Quick'n'dirty - only checked with DDT master, and Django 2.2.x.