### PR TITLE
Handle possible division by zero in _calc_p

### DIFF
--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -129,7 +129,8 @@ class TemplateProfilerPanel(Panel):
         self.is_enabled = False
 
     def _calc_p(self, part, whole):
-        return (part / whole) * 100.0
+        # return the percentage of part or 100% if whole is zero
+        return (part / whole) * 100.0 if whole else 100.0
 
     def _calc_timeline(self, start, end):
         result = {}


### PR DESCRIPTION
Thanks for the great work 😄 
The following minimal django app causes the plugin to raise a `ZeroDivisionError`:
```
# self-contained django app based on 
# https://github.com/wsvincent/django-microframework#option-2

from django.conf import settings
from django.core.handlers.wsgi import WSGIHandler
from django.core.management import execute_from_command_line
from django.http import HttpResponse
from django.urls import include, path
import debug_toolbar
from django.template import Template, Context


settings.configure(
    ROOT_URLCONF=__name__,
    DEBUG=True,
    INSTALLED_APPS=[
        'django.contrib.staticfiles',
        'debug_toolbar',
        'template_profiler_panel',
    ],
    TEMPLATES=[
        {
            'BACKEND': 'django.template.backends.django.DjangoTemplates',
            'APP_DIRS': True,
        }
    ],
    STATIC_URL='/static/',
    MIDDLEWARE=['debug_toolbar.middleware.DebugToolbarMiddleware'],
    INTERNAL_IPS=['127.0.0.1'],
    DEBUG_TOOLBAR_PANELS=[
        'debug_toolbar.panels.timer.TimerPanel',
        'template_profiler_panel.panels.template.TemplateProfilerPanel',
    ],
)


def empty_page(request):
    t = Template("<html><body></body></html>")
    return HttpResponse(t.render(Context({})))


urlpatterns = [
    path('__debug__/', include(debug_toolbar.urls)),
    path('', empty_page)
]

application = WSGIHandler()


if __name__ == "__main__":
    execute_from_command_line()
```

## Steps:
 1. Save the above code snippet into a file `main.py`.
 2. Run `python main.py runserver`.
 3. Open the page in the browser http://127.0.0.1:8000/.
 4. Keep refreshing the page until it eventually loads in `0.0` seconds and the plugin crashes.

This PR fixes the crash by changing `_calc_p` to return `100%` when `whole` is `0`.