### PR TITLE
fix timeline (at least in Chrome)

### DIFF
--- a/template_profiler_panel/templates/template_profiler_panel/template.html
+++ b/template_profiler_panel/templates/template_profiler_panel/template.html
@@ -25,8 +25,8 @@
         <td>{{ template.name }}</td>
         <td class="timeline">
           <div class="djDebugTimeline">
-            <div class="djDebugLineChart" style="left: {{ template.offset_p|stringformat:'f' }}%;">
-              <strong title="Start {{ template.start }}" style="min-width: 1px; width: {{ template.rel_duration_p|stringformat:'f' }}%; background-color: {{ template.color.bg }};">&nbsp;</strong>
+            <div class="djDebugLineChart" style="margin-left: {{ template.offset_p|stringformat:'f' }}%;">
+              <div title="Start {{ template.start }}" style="min-width: 1px; width: {{ template.rel_duration_p|stringformat:'f' }}%; background-color: {{ template.color.bg }};">&nbsp;</div>
             </div>
           </div>
         </td>


### PR DESCRIPTION
In chrome the timeline is compressed on left side with no meaning. This fixes the problem.