### PR TITLE
[experimental] Profile methods of view class

### DIFF
--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -28,6 +28,16 @@ node_element_colors = {}
 
 @wrapt.decorator
 def profile_method(wrapped, instance, args, kwargs):
+    """
+
+    Profile method decorator
+    Usage:
+
+    from template_profiler_panel.panels.template import profile_method
+    @profile method
+    def method():
+        ...
+    """
     start = time()
 
     result = wrapped(*args, **kwargs)
@@ -46,6 +56,34 @@ def profile_method(wrapped, instance, args, kwargs):
         level=1,
     )
     return result
+
+
+class Profile:
+    """
+    Profile with block
+    Usage:
+
+    from template_profiler_panel.panels.template import Profile
+    with Profile("block name"):
+        ...
+    """
+    def __init__(self, name="Profile with", *args, **kwargs):
+        self.name = name
+
+    def __enter__(self):
+        self.start = time()
+
+    def __exit__(self, type, value, traceback):
+        self.end = time()
+
+        template_rendered.send(
+            sender=self.__class__,
+            instance=self.name,
+            start=self.start,
+            end=self.end,
+            processing_timeline=[],
+            level=1,
+        )
 
 
 def get_nodelist_timeline(nodelist, level):

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import defaultdict
+from collections.abc import Callable
 from time import time
 
 import wrapt
@@ -7,6 +8,8 @@ from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.utils import contrasting_color_generator
 import django
 from django.dispatch import Signal
+from django.urls import resolve
+
 
 if django.VERSION < (3, 2):
     from django.utils.translation import ugettext_lazy as _
@@ -21,6 +24,28 @@ else:
     template_rendered = Signal()
 
 node_element_colors = {}
+
+
+@wrapt.decorator
+def profile_method(wrapped, instance, args, kwargs):
+    start = time()
+
+    result = wrapped(*args, **kwargs)
+    end = time()
+
+    instance_name = (
+        (wrapped.__self__.__class__.__name__ + ".")
+        if hasattr(wrapped, '__self__') else ""
+    ) + wrapped.__name__
+    template_rendered.send(
+        sender=instance.__class__,
+        instance=instance_name,
+        start=start,
+        end=end,
+        processing_timeline=[],
+        level=1,
+    )
+    return result
 
 
 def get_nodelist_timeline(nodelist, level):
@@ -76,6 +101,22 @@ class TemplateProfilerPanel(Panel):
         super(TemplateProfilerPanel, self).__init__(*args, **kwargs)
 
     have_monkey_patched_template_classes = False
+
+    def generate_stats(self, request, response):
+        match = resolve(request.path)
+        func, args, kwargs = match
+        view_class = getattr(func, 'view_class', None)
+        if view_class and not hasattr(view_class, '_profile_enabled'):
+            print(view_class)
+            view_class._profile_enabled = True
+            for attr in view_class.__dict__:
+                print(attr)
+                if isinstance(getattr(view_class, attr), Callable):
+                    setattr(
+                        view_class,
+                        attr,
+                        profile_method(getattr(view_class, attr)),
+                    )
 
     @classmethod
     def monkey_patch_template_classes(cls):
@@ -160,7 +201,10 @@ class TemplateProfilerPanel(Panel):
         if not self.enabled:
             return
 
-        template_name = instance.name
+        try:
+            template_name = instance.name
+        except AttributeError:
+            template_name = instance
         # Logic copied from django-debug-toolbar:
         # https://github.com/jazzband/django-debug-toolbar/blob/5d095f66fde8f10b45a93c0b35be0a85762b0458/debug_toolbar/panels/templates/panel.py#L77
         is_skipped_template = isinstance(template_name, str) and (


### PR DESCRIPTION
This is experimental and unfinished code, which adds profiling of all methods of view class. The PR contains commits from #17, but I can also rebase them out. This functionality is much simpler than the whole changelog - only the last commit.

I wanted to know more about my views timing, so I also runtimes of the view functions:
![Snímek z 2021-01-16 16-28-18](https://user-images.githubusercontent.com/156755/104815900-e25a6880-5817-11eb-84ae-6a7544cb278c.png)

It is not perfect yet - for example the view has to be executed twice in order to patch the class correctly. I am not sure how to solve this, but I also didn't give it much time yet.
Also it probably doesn't work for function base views, but I don't think it would be such problem to fix it.

I know, that this might be out of scope of this DJDT panel, but I would also don't want copy the code out of this package, because most of the code is shared. I also didn't find other DJDT panel with this functionality - the profiling panels I found were hard to set-up and did produce very complicated and unclear output.

So what do you think? Should this be made into this panel (which would then be `view-profiler` rather than `template-profiler`)?