### PR TITLE
Django 3.1 through 4.1 compatibility changes

### DIFF
--- a/template_profiler_panel/__init__.py
+++ b/template_profiler_panel/__init__.py
@@ -1,2 +1,3 @@
+import django
 if django.VERSION < (4, 0):
     default_app_config = "template_profiler_panel.apps.TemplateProfilerPanelAppConfig"

--- a/template_profiler_panel/__init__.py
+++ b/template_profiler_panel/__init__.py
@@ -1,1 +1,2 @@
-default_app_config = "template_profiler_panel.apps.TemplateProfilerPanelAppConfig"
+if django.VERSION < (4, 0):
+    default_app_config = "template_profiler_panel.apps.TemplateProfilerPanelAppConfig"

--- a/template_profiler_panel/__init__.py
+++ b/template_profiler_panel/__init__.py
@@ -1,3 +1,3 @@
 import django
-if django.VERSION < (4, 0):
+if django.VERSION < (3, 2):
     default_app_config = "template_profiler_panel.apps.TemplateProfilerPanelAppConfig"

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -6,8 +6,11 @@ import wrapt
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.utils import contrasting_color_generator
 from django.dispatch import Signal
-from django.utils.translation import ugettext_lazy as _
-
+if django.VERSION < (3, 2):
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
+    
 template_rendered = Signal(providing_args=[
     'instance', 'start', 'end', 'level', 'processing_timeline',
 ])

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -10,11 +10,13 @@ if django.VERSION < (3, 2):
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
-    
-template_rendered = Signal(providing_args=[
-    'instance', 'start', 'end', 'level', 'processing_timeline',
-])
-
+   
+if django.VERSION < (3, 1):
+    template_rendered = Signal(providing_args=[
+        'instance', 'start', 'end', 'level', 'processing_timeline',
+    ])
+else:
+    template_rendered = Signal()
 
 node_element_colors = {}
 

--- a/template_profiler_panel/panels/template.py
+++ b/template_profiler_panel/panels/template.py
@@ -5,7 +5,9 @@ from time import time
 import wrapt
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.utils import contrasting_color_generator
+import django
 from django.dispatch import Signal
+
 if django.VERSION < (3, 2):
     from django.utils.translation import ugettext_lazy as _
 else:


### PR DESCRIPTION
Fixed #19 with changes for Django 3.1, 3.2, 4.0 by switching imports, switching usage of Signal and removing default_app_config when no longer required